### PR TITLE
import bead contacts from textfile

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,12 @@ def main(gui_enabled):
         for file in files_for_further_processing:
             file_path = os.path.join(input_directory, file)
             bead_contact_gui = BeadContactGUI(file, file_path, info_saver.bead_contact_dict, parameters)
-            bead_contact_gui.run_main_loop()
+            # If contacts were loaded, skip GUI interaction
+            if bead_contact_gui.bead_contacts:
+                print(f"Following Bead contacts were loaded from file for {file}: {bead_contact_gui.bead_contacts}")
+                bead_contact_gui.close_gui()
+            else:
+                bead_contact_gui.run_main_loop()
             del bead_contact_gui
 
         # save bead contacts on computer

--- a/src/analysis/Bead_Contact_GUI.py
+++ b/src/analysis/Bead_Contact_GUI.py
@@ -1,5 +1,7 @@
 import tkinter
 
+import re
+
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 from tkinter import (Tk, Label, Scale, Listbox, Scrollbar, Frame, Button, Radiobutton, IntVar, Text, HORIZONTAL, END)
@@ -109,6 +111,43 @@ class BeadContactGUI():
 
         self.cancel_button = Button(self.input_frame, text='Cancel', command=self.cancel)
         self.cancel_button.grid(row=11, column=0, sticky="W")
+
+        #Try to load bead contacts from file
+        bead_contact_info_path = parameters["input_output"]["results_dir"] + '/Bead_contact_information.txt'
+        self.load_bead_contacts_from_file(bead_contact_info_path)
+
+
+    def load_bead_contacts_from_file(self, bead_contact_info_path):
+        try:
+            with open(bead_contact_info_path, 'r') as f:
+                content = f.read()
+            # Split by filenames
+            entries = re.split(r'Filename: ', content)
+            for entry in entries:
+                if not entry.strip():
+                    continue
+                lines = entry.strip().split('\n')
+                filename = lines[0].strip()
+                if filename == self.file:
+                    self.bead_contacts = []
+                    for line in lines[1:]:
+                        if line.startswith(" Bead contact: "):
+                            bead_contact_str = line.replace(" Bead contact: ", "")
+                            # Parse the string to extract values
+                            match = re.match(
+                                r'bead contact position\((\d+), (\d+)\)- frame: (\d+)- position inside cell: \((\d+), (\d+)\)',
+                                bead_contact_str
+                            )
+                            if match:
+                                x, y, frame, x_cell, y_cell = map(int, match.groups())
+                                bead_contact = BeadContact((x, y), frame, (x_cell, y_cell))
+                                self.bead_contacts.append(bead_contact)
+                                self.bead_contact_list.insert(END, bead_contact.to_string())
+                    return True
+            return False
+        except Exception as e:
+            print("Error loading bead contact info:", e)
+            return False
 
     def cancel(self):
         self.root.destroy()


### PR DESCRIPTION
For each video that already has at least one bead contact listed in the results folder: load bead contacts from textfile and skip GUI. This allows restarting the analysis when hotspot detection is interrupted due to errors or additional timepoints need to be processed without the need to manually input each bead contact again.